### PR TITLE
add missing import

### DIFF
--- a/getindex.py
+++ b/getindex.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 from elasticsearch import Elasticsearch
+import elasticsearch
 import json
 from pprint import pprint
 import argparse


### PR DESCRIPTION
It's required in [line 22](https://github.com/slub/slub-lod-elasticsearch-tools/compare/master...miku:add-missing-import?expand=1#diff-6d2a82803836c4eb3306249747035148R22).